### PR TITLE
fix typo in documentation

### DIFF
--- a/lib/MooseX/AttributeTags.pm
+++ b/lib/MooseX/AttributeTags.pm
@@ -91,7 +91,7 @@ MooseX::AttributeTags - tag your Moose attributes
    
    use Moose;
    use MooseX::Types::Moose 'Bool';
-   use MooseX::AttributeTraits (
+   use MooseX::AttributeTags (
       SerializationStyle => [
          hidden => Bool,
       ],


### PR DESCRIPTION
wrong class name

Apologies for the brevity and/or any mistakes;  This was typed on a mobile computing device without a proper keyboard.
