### PR TITLE
Fix module name typo in synopsis

### DIFF
--- a/lib/MooseX/AttributeTags.pm
+++ b/lib/MooseX/AttributeTags.pm
@@ -91,7 +91,7 @@ MooseX::AttributeTags - tag your Moose attributes
    
    use Moose;
    use MooseX::Types::Moose 'Bool';
-   use MooseX::AttributeTraits (
+   use MooseX::AttributeTags (
       SerializationStyle => [
          hidden => Bool,
       ],


### PR DESCRIPTION
AttributeTraits → AttributeTags